### PR TITLE
FIX: Invoke "get_image_by_id" before "tag_image"

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -286,7 +286,8 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
                 image_region=push_item.region,
             )
             result = UploadResult(copy_result["ImageId"])
-        upload_svc.tag_image(result.id, tags)
+        image = upload_svc.get_image_by_id(result.id)
+        upload_svc.tag_image(image, tags)
         return result
 
     def _upload(

--- a/tests/cloud_providers/test_provider_aws.py
+++ b/tests/cloud_providers/test_provider_aws.py
@@ -247,17 +247,21 @@ def test_upload_of_rhcos_image(
     fake_aws_provider.upload_svc_partial.return_value.copy_ami.return_value = {  # type: ignore [attr-defined] # noqa: E501
         "ImageId": "fake-ami-02"
     }
-    fake_aws_provider.upload_svc_partial.return_value.get_image_by_name.return_value = (  # type: ignore [attr-defined] # noqa: E501
-        None
-    )
+    fake_aws_provider.upload_svc_partial.return_value.get_image_by_name.return_value = None
+    fake_aws_provider.upload_svc_partial.return_value.get_image_by_id.return_value = "test_image"
 
     _, result = fake_aws_provider.upload(aws_rhcos_push_item)
     assert result.id == "fake-ami-02"
     fake_aws_provider.upload_svc_partial.return_value.get_image_from_ami_catalog.assert_called_once()  # type: ignore [attr-defined] # noqa: E501
-    fake_aws_provider.upload_svc_partial.return_value.get_image_by_name.assert_called_once()  # type: ignore [attr-defined] # noqa: E501
+    fake_aws_provider.upload_svc_partial.return_value.get_image_by_name.assert_called_once_with(
+        "rhcos-x86_64-414.92.202405201754-0"
+    )
+    fake_aws_provider.upload_svc_partial.return_value.get_image_by_id.assert_called_once_with(
+        "fake-ami-02"
+    )
     fake_aws_provider.upload_svc_partial.return_value.copy_ami.assert_called_once()  # type: ignore [attr-defined] # noqa: E501
     fake_aws_provider.upload_svc_partial.return_value.tag_image.assert_called_once_with(
-        "fake-ami-02", tags
+        "test_image", tags
     )
 
 


### PR DESCRIPTION
We must send the actual EC2 image object to "tag_image" and not a string, otherwise it won't properly work.