### PR TITLE
Release  v0.12.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pushcollector>=1.3.0
 pushsource>=2.44.0
 strenum>=0.4.15
 starmap-client>=1.3.0
-cloudpub>=0.9.2
+cloudpub>=0.9.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_requirements():
 
 setup(
     name="pubtools-marketplacesvm",
-    version="0.12.4",
+    version="0.12.5",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     url="https://gitlab.cee.redhat.com/stratosphere/pubtools-marketplacesvm",


### PR DESCRIPTION
Changes:
    
- Bump `cloudpub` to `v0.9.3`
- Add test to push item with no destinations
- Fix bug preventing to upload RHCOS image