### PR TITLE
Completely remove stage_preview feature

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -433,7 +433,6 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
         push_item: AmiPushItem,
         nochannel: bool,
         overwrite: bool = False,
-        preview_only=False,
         **kwargs,
     ) -> Tuple[AmiPushItem, Any]:
         """

--- a/src/pubtools/_marketplacesvm/cloud_providers/base.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/base.py
@@ -122,7 +122,6 @@ class CloudProvider(ABC, Generic[T, C]):
         push_item: T,
         nochannel: bool,
         overwrite: bool = False,
-        preview_only: bool = False,
         **kwargs,
     ) -> Tuple[T, Any]:
         """
@@ -136,9 +135,6 @@ class CloudProvider(ABC, Generic[T, C]):
             overwrite (bool, optional)
                 Whether to replace every image in the product with the given one or not.
                 Defaults to ``False``
-            preview_only (bool, optional)
-                Whether to publish with the final state as "preview" instead of "live"
-                when applicable.
         """
 
     #
@@ -230,7 +226,6 @@ class CloudProvider(ABC, Generic[T, C]):
         push_item: T,
         nochannel: bool,
         overwrite: bool = False,
-        preview_only: bool = False,
         **kwargs,
     ) -> Tuple[T, Any]:
         """
@@ -244,13 +239,10 @@ class CloudProvider(ABC, Generic[T, C]):
                 set to `False`.
             overwrite (bool, optional)
                 Whether set only the requested image and erase everything else or not.
-            preview_only (bool, optional)
-                Whether to publish with the final state as "preview" instead of "live"
-                when applicable.
         Returns:
             object: The publish result data.
         """
-        pi, res = self._publish(push_item, nochannel, overwrite, preview_only, **kwargs)
+        pi, res = self._publish(push_item, nochannel, overwrite, **kwargs)
         return self._post_publish(pi, res, nochannel, **kwargs)
 
 

--- a/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
@@ -270,7 +270,6 @@ class AzureProvider(CloudProvider[VHDPushItem, AzureCredentials]):
         push_item: VHDPushItem,
         nochannel: bool,
         overwrite: bool = False,
-        preview_only: bool = False,
         **kwargs,
     ) -> Tuple[VHDPushItem, Any]:
         """
@@ -284,8 +283,6 @@ class AzureProvider(CloudProvider[VHDPushItem, AzureCredentials]):
             overwrite (bool, optional)
                 Whether to replace every image in the product with the given one or not.
                 Defaults to ``False``
-            preview_only (bool, optional)
-                Whether to publish with the final state as "preview" instead of "live"
         """
         if not push_item.disk_version:
             push_item = evolve(push_item, disk_version=self._generate_disk_version(push_item))
@@ -305,7 +302,6 @@ class AzureProvider(CloudProvider[VHDPushItem, AzureCredentials]):
             "destination": destination,
             "keepdraft": nochannel,
             "overwrite": overwrite,
-            "preview_only": preview_only,
         }
         metadata = AzurePublishMetadata(**publish_metadata_kwargs)
         res = self.publish_svc.publish(metadata)

--- a/tests/cloud_providers/conftest.py
+++ b/tests/cloud_providers/conftest.py
@@ -29,7 +29,6 @@ class FakeProvider(CloudProvider):
         push_item: T,
         nochannel: bool,
         overwrite: bool = False,
-        preview_only: bool = False,
         **kwargs,
     ) -> Tuple[T, Any]:
         return push_item, True

--- a/tests/cloud_providers/test_provider_azure.py
+++ b/tests/cloud_providers/test_provider_azure.py
@@ -225,7 +225,6 @@ def test_publish(
         "destination": azure_push_item.dest[0],
         "keepdraft": False,
         "overwrite": False,
-        "preview_only": False,
     }
     meta_obj = MagicMock(**metadata)
     mock_metadata.return_value = meta_obj

--- a/tests/combined_push/test_combined_push.py
+++ b/tests/combined_push/test_combined_push.py
@@ -43,7 +43,7 @@ class FakeCloudProvider(CloudProvider):
     def _pre_publish(self, push_item, **kwargs):
         return push_item, kwargs
 
-    def _publish(self, push_item, nochannel, overwrite, preview_only, **kwargs):
+    def _publish(self, push_item, nochannel, overwrite, **kwargs):
         return push_item, nochannel
 
 

--- a/tests/community_push/test_community_push.py
+++ b/tests/community_push/test_community_push.py
@@ -40,7 +40,7 @@ class FakeCloudProvider(CloudProvider):
     def _pre_publish(self, push_item, **kwargs):
         return push_item, kwargs
 
-    def _publish(self, push_item, nochannel, overwrite, preview_only):
+    def _publish(self, push_item, nochannel, overwrite, **kwargs):
         return push_item, nochannel
 
 

--- a/tests/push/test_push.py
+++ b/tests/push/test_push.py
@@ -30,7 +30,7 @@ class FakeCloudProvider(CloudProvider):
     def _pre_publish(self, push_item, **kwargs):
         return push_item, kwargs
 
-    def _publish(self, push_item, nochannel, overwrite, preview_only, **kwargs):
+    def _publish(self, push_item, nochannel, overwrite, **kwargs):
         return push_item, nochannel
 
 
@@ -112,7 +112,7 @@ def test_do_push_ami_correct_id(
         def _pre_publish(self, push_item, **kwargs):
             return push_item, kwargs
 
-        def _publish(self, push_item, nochannel, overwrite, preview_only, **kwargs):
+        def _publish(self, push_item, nochannel, overwrite, **kwargs):
             # This log will allow us to identify whether the image_id is the expected
             self.log.debug(f"Pushing {push_item.name} with image: {push_item.image_id}")
             return push_item, nochannel
@@ -192,7 +192,7 @@ def test_do_push_azure_correct_sas(
         def _pre_publish(self, push_item, **kwargs):
             return push_item, kwargs
 
-        def _publish(self, push_item, nochannel, overwrite, preview_only, **kwargs):
+        def _publish(self, push_item, nochannel, overwrite, **kwargs):
             # This log will allow us to identify whether the sas_uri is the expected
             self.log.debug(f"Pushing {push_item.name} with image: {push_item.sas_uri}")
             return push_item, nochannel
@@ -448,7 +448,7 @@ def test_push_item_fail_publish(
     """Test a push which fails on publish for AWS."""
 
     class FakePublish(FakeCloudProvider):
-        def _publish(self, push_item, nochannel, overwrite, preview_only, **kwargs):
+        def _publish(self, push_item, nochannel, overwrite, **kwargs):
             raise Exception("Random exception")
 
     mock_cloud_instance.return_value = FakePublish()


### PR DESCRIPTION
Remove the leftovers of `stage_preview` feature which was used to perform a publishing with the final status as preview.

This is no longer supported and there's no need to keep its interfaces/calls in the code.