### PR TITLE
Changes name to generated name and adds region (if default) 

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -342,6 +342,10 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
         snapshot_accounts = kwargs.get("snapshot_accounts") or default_snapshot_accounts
         container = kwargs.get("container") or self.s3_bucket
         LOG.info("Image name: %s | Sharing groups: %s", name, groups)
+        # Update some items in push_item
+        region = push_item.region or self.default_region
+        push_item = evolve(push_item, region=region)
+        push_item = evolve(push_item, name=name)
 
         tags = {
             "nvra": f"{binfo.name}-{binfo.version}-{binfo.release}.{push_item.release.arch}",
@@ -390,8 +394,7 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
         LOG.debug("%s", upload_metadata_kwargs)
         metadata = AWSUploadMetadata(**upload_metadata_kwargs)
 
-        region = push_item.region or self.default_region
-        res = self.upload_svc_partial(region=region).publish(metadata)
+        res = self.upload_svc_partial(region=push_item.region).publish(metadata)
         return push_item, res
 
     def _post_upload(

--- a/tests/cloud_providers/test_provider_aws.py
+++ b/tests/cloud_providers/test_provider_aws.py
@@ -333,11 +333,13 @@ def test_upload(
 
     fake_aws_provider.upload_svc_partial.return_value.publish.return_value = FakeImageResp()  # type: ignore [attr-defined] # noqa: E501
 
-    fake_aws_provider.upload(aws_push_item)
+    updated_push_item, _ = fake_aws_provider.upload(aws_push_item)
 
     mock_metadata.assert_called_once_with(**metadata)
     fake_aws_provider.upload_svc_partial.return_value.publish.assert_called_once_with(meta_obj)  # type: ignore [attr-defined] # noqa: E501
     fake_aws_provider.publish_svc.publish.assert_not_called()
+    assert updated_push_item.name == "base_product-1.1-sample_product-1.0_VIRT_GA-20230130-x86_64-0"
+    assert updated_push_item.region == "us-east-1"
 
 
 @pytest.mark.parametrize("region", ["us-gov-west-1", "eu-north-1", "cn-north-1"])


### PR DESCRIPTION
Updated to include some missing data from push_item. Region will now be set even when using the default. Name will be updated to use the generated name before upload.