### PR TITLE
Release 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pushcollector>=1.3.0
 pushsource>=2.44.0
 strenum>=0.4.15
 starmap-client>=1.3.0
-cloudpub>=0.9.3
+cloudpub>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_requirements():
 
 setup(
     name="pubtools-marketplacesvm",
-    version="0.12.5",
+    version="1.0.0",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     url="https://gitlab.cee.redhat.com/stratosphere/pubtools-marketplacesvm",


### PR DESCRIPTION
Changes:
    
    - Completely remove stage_preview feature
    - Changes name to generated name and adds region (if default) to push_item.
    - Fix sharing accounts bug on CommunityVMPush
    - Use a common sharing_accounts format for AWS
    - Add volume property to Community Tests
    - CommunityWorkflow: Rename aarch64 to arm64
    - Bump cloudpub to v1.0.0
