### PR TITLE
Support StArMap responses on --repo in pubtools-marketplacesvm

### DIFF
--- a/tests/push/test_push.py
+++ b/tests/push/test_push.py
@@ -504,13 +504,15 @@ def test_push_overridden_destination(
             "eyJtYXJrZXRwbGFjZV9hY2NvdW50IjogInRlc3QtbmEiLCAiYXV0aCI6eyJmb28iOiJiYXIifQo=",
             "--repo",
             "{"
-            "    \"aws-na\": {\"destination\": \"new_aws_na_destination\", \"restrict_version\": false},"  # noqa: E501
-            "    \"aws-emea\": {\"destination\": \"new_aws_emea_destination\", \"overwrite\": true, \"restrict_version\": false},"  # noqa: E501
+            "\"mappings\": {"
+            "    \"aws-na\": [{\"destination\": \"new_aws_na_destination\", \"overwrite\": false, \"restrict_version\": false}],"  # noqa: E501
+            "    \"aws-emea\": [{\"destination\": \"new_aws_emea_destination\", \"overwrite\": true, \"restrict_version\": false}],"  # noqa: E501
             "    \"azure-na\": [ "
             "    {\"destination\": \"new_azure_destination1\", \"overwrite\": true, \"restrict_version\": false},"  # noqa: E501
-            "    {\"destination\": \"new_azure_destination2\", \"restrict_version\": false}"  # noqa: E501
+            "    {\"destination\": \"new_azure_destination2\", \"overwrite\": false, \"restrict_version\": false}"  # noqa: E501
             "]"
-            "}",
+            "},"
+            "\"name\": \"sample-product\", \"workflow\": \"stratosphere\"}",
             "--debug",
             "koji:https://fakekoji.com?vmi_build=ami_build,azure_build",
         ],


### PR DESCRIPTION
As one of the changes required for supporting [Konflux](https://konflux-ci.dev/docs/) in the future we want to support passing [StArMap's QueryResponse](https://release-engineering.github.io/starmap-client/model/models.html#starmap_client.models.QueryResponse) on the `--repo` argument from pubtools-marketplacesvm


This PR adds the following changes:

1. Implement RepoQueryLoad action
    
    This commit implements a new ArgParse action named `RepoQueryLoad` which
    is responsible to load a JSON string from argument and convert it to a
    list of StArMap's `QueryResponse` objects.
    
    As a consequence of parsing the data as `QueryResponse` we also get the
    validation from the `starmap_client` library.
    
    It will be used to replace the way we load data from `--repo`.

2. Update repo argument to load QueryResponse
    
    This commit changes the stratosphere workflow when overriding the
    StArMap queries, as it will now receive a complete QueryResponse from
    the `--repo` argument instead of a dictionary.
    
    Note that even though we're now using the `RepoQueryLoad` action, which
    creates a list of QueryResponse objects, it's still not possible to have
    multiple mappings definition as we will implement the management of such
    list in the `starmap_client` library.
    
    What we have now is just a drop in replacement for the existing `--repo`
    feature which behaves the same way but receives a different format from
    its input.

Refers to SPSTRAT-323