### PR TITLE
Azure: Remove unnecessary "AZURE_PUBLISHER_NAME"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pushcollector>=1.3.0
 pushsource>=2.44.0
 strenum>=0.4.15
 starmap-client>=1.4.1
-cloudpub>=1.0.0
+cloudpub>=1.0.1

--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -75,6 +75,10 @@ def name_from_push_item(push_item: AmiPushItem) -> str:
 class AWSCredentials(CloudCredentials):
     """Represent the credentials for AWSProvider."""
 
+    def __init__(self, **kwargs):
+        """Initialize the AWSCredentials."""
+        super(AWSCredentials, self).__init__(**kwargs)
+
     aws_image_access_key: str = field(alias="AWS_IMAGE_ACCESS_KEY", validator=instance_of(str))
     """AWs Image access key."""
 

--- a/src/pubtools/_marketplacesvm/cloud_providers/base.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/base.py
@@ -38,6 +38,15 @@ class MarketplaceAuth(TypedDict):
 class CloudCredentials:
     """The base class for a cloud provider credentials."""
 
+    def __init__(self, **kwargs):
+        """Initialize the CloudCredentials by filtering out extra args."""
+        filtered = {
+            attribute.alias: kwargs[attribute.alias]
+            for attribute in self.__attrs_attrs__
+            if attribute.alias in kwargs
+        }
+        self.__attrs_init__(**filtered)
+
     cloud_name: str = field(
         validator=instance_of(str),
         converter=lambda x: x.lower() if isinstance(x, str) else x,

--- a/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
@@ -21,8 +21,9 @@ LOG = logging.getLogger("pubtools.marketplacesvm")
 class AzureCredentials(CloudCredentials):
     """Represent the credentials for AzureProvider."""
 
-    azure_publisher_name: str = field(alias="AZURE_PUBLISHER_NAME", validator=instance_of(str))
-    """The publisher name."""
+    def __init__(self, **kwargs):
+        """Initialize the AzureCredentials."""
+        super(AzureCredentials, self).__init__(**kwargs)
 
     azure_tenant_id: str = field(alias="AZURE_TENANT_ID", validator=instance_of(str))
     """Tenant ID for Azure Marketplace."""


### PR DESCRIPTION
During 1p tests we found out that the `AZURE_PUBLISHER_NAME` for Azure Credentials wasn't being used at all in the library's code.

After doing some tests I've confirmed this property is not required, so this commit removes it.