### PR TITLE
AzureProvider: Allow forcing push draft offers

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -157,7 +157,7 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
     ARCH_ALIASES: Dict[str, str] = {"aarch64": "arm64"}
     """Dictionary of aliases for architecture names between brew and AWS."""
 
-    def __init__(self, credentials: AWSCredentials) -> None:
+    def __init__(self, credentials: AWSCredentials, **kwargs) -> None:
         """
         Create an instance of AWSProvider.
 

--- a/tests/cloud_providers/test_provider_azure.py
+++ b/tests/cloud_providers/test_provider_azure.py
@@ -245,7 +245,7 @@ def test_publish(
 
 
 @patch("pubtools._marketplacesvm.cloud_providers.ms_azure.AzurePublishMetadata")
-def test_publish_allow_draft(
+def test_publish_allow_draft_from_env(
     mock_metadata: MagicMock,
     fake_credentials: AzureCredentials,
     azure_push_item: VHDPushItem,
@@ -272,6 +272,44 @@ def test_publish_allow_draft(
     # Set environment to allow draft push and create a provider with the patched data
     monkeypatch.setenv("AZURE_ALLOW_DRAFT_PUSH", "true")
     provider = AzureProvider(fake_credentials)
+    monkeypatch.setattr(provider, 'upload_svc', MagicMock())
+    monkeypatch.setattr(provider, 'publish_svc', MagicMock())
+    monkeypatch.setattr(provider, '_generate_disk_version', mock_generate_dv)
+    monkeypatch.setattr(provider, 'ensure_offer_is_writable', mock_ensure_offer_writable)
+
+    # Test
+    provider.publish(azure_push_item, nochannel=False, overwrite=False)
+
+    # Ensure the draft lock was not called
+    mock_ensure_offer_writable.assert_not_called()
+
+
+@patch("pubtools._marketplacesvm.cloud_providers.ms_azure.AzurePublishMetadata")
+def test_publish_allow_draft_from_init(
+    mock_metadata: MagicMock,
+    fake_credentials: AzureCredentials,
+    azure_push_item: VHDPushItem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    azure_push_item = evolve(azure_push_item, disk_version=None)
+    mock_generate_dv = MagicMock()
+    mock_generate_dv.return_value = "7.0.202301010000"
+    metadata = {
+        "sku_id": azure_push_item.sku_id,
+        "generation": azure_push_item.generation or "V2",
+        "support_legacy": azure_push_item.support_legacy or False,
+        "recommended_sizes": azure_push_item.recommended_sizes or [],
+        "legacy_sku_id": azure_push_item.legacy_sku_id,
+        "image_path": azure_push_item.sas_uri,
+        "architecture": azure_push_item.release.arch,
+        "destination": azure_push_item.dest[0],
+        "keepdraft": False,
+        "overwrite": False,
+    }
+    mock_metadata.return_value = MagicMock(**metadata)
+    mock_ensure_offer_writable = MagicMock()
+
+    provider = AzureProvider(fake_credentials, allow_draft_push=True)
     monkeypatch.setattr(provider, 'upload_svc', MagicMock())
     monkeypatch.setattr(provider, 'publish_svc', MagicMock())
     monkeypatch.setattr(provider, '_generate_disk_version', mock_generate_dv)

--- a/tests/services/test_services.py
+++ b/tests/services/test_services.py
@@ -97,6 +97,14 @@ def test_azure_provider_service(
             # Single AzureProvider instance per thread
             assert instance.cloud_instance("azure-na") == provider
 
+    # Test allow draft push
+    with patch("pubtools._marketplacesvm.services.cloud.get_provider") as mock_getprvdr:
+        instance = MarketplacesVMPush()
+        arg = ["", "--credentials", str(creds_file), "--azure-allow-draft-push", "fakesource"]
+        with patch.object(sys, "argv", arg):
+            provider = instance.cloud_instance("azure-na")
+            mock_getprvdr.assert_called_once_with(fake_auth, allow_draft_push=True)
+
     # Test invalidcredentials
     with caplog.at_level(logging.INFO):
         with pytest.raises(ValueError, match="Invalid credentials"):


### PR DESCRIPTION
This commit changes the `AzureProvider` by adding a new environment variable named `AZURE_ALLOW_DRAFT_PUSH` which when set to `true` will make the method `ensure_offer_is_writable` not be called during the publish process thus allowing the push to draft offers.