### PR TITLE
Fix regression on community sharing accounts

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/community_push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/community_push/command.py
@@ -303,7 +303,7 @@ class CommunityVMPush(MarketplacesVMPush, AwsRHSMClientService):
             if isinstance(accts, dict):
                 combined_accts = []
                 for _, accounts in accts.items():  # expected format: Dict[str, List[str]]
-                    combined_accts.append(accounts)
+                    combined_accts.extend(accounts)
                     log.debug("Loaded \"%s\": \"%s\".", acct_name, accounts)
                 acct_dict.setdefault(acct_name, combined_accts)
             elif isinstance(accts, list):  # expected format: List[str]


### PR DESCRIPTION
This commit fixes a regression on community sharing accounts caused by #13

The issue in question is caused by appending the `accounts` list into `combined_accts`, leaving it as a `List[List[str]]` instead of `List[str]`.

The fix a simple one line change.

Refers to SPSTRAT-338