### PR TITLE
Adds index reference to delete command

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Virtual Machine images to various cloud marketplaces.
    combined_push
    marketplace_push
    community_push
+   delete
 
 
 .. toctree::


### PR DESCRIPTION
Fixes the docs index.rst reference to delete. Was missing.