### PR TITLE
Community: Allow using beta from push item

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/community_push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/community_push/command.py
@@ -300,11 +300,10 @@ class CommunityVMPush(MarketplacesVMPush, AwsRHSMClientService):
 
                 pi = mapped_item.get_push_item_for_marketplace(storage_account)
                 log.debug("Mapped push item for %s: %s", storage_account, pi)
+                beta = self.args.beta or str(pi.release.type) == "beta"
 
                 for dest in destinations:
-                    epi = enrich_push_item(
-                        pi, dest, beta=self.args.beta, require_bc=self._REQUIRE_BC
-                    )
+                    epi = enrich_push_item(pi, dest, beta=beta, require_bc=self._REQUIRE_BC)
                     log.debug("Enriched push item for %s: %s", storage_account, epi)
 
                     # SAP and RHEL-HA images are expected to be


### PR DESCRIPTION
This commit changes the community workflow to enrich a push item with "beta" if either the CLI argument `--beta` is passed or the incoming push item release type is marked as `beta`.

Refers to SPSTRAT-367