### PR TITLE
Switches from locked threads to async on publish

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import asyncio
 import datetime
 import json
 import logging
@@ -266,7 +267,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
             res.append((mapped_item, starmap_query))
         return res
 
-    def _push_publish(self, upload_result: List[UPLOAD_RESULT]) -> List[Dict[str, Any]]:
+    async def _push_publish(self, upload_result: List[UPLOAD_RESULT]) -> List[Dict[str, Any]]:
         """
         Perform the publishing for the the VM images.
 
@@ -277,7 +278,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
             Dictionary with the resulting operation for the Collector service.
         """
 
-        def push_function(mapped_item, marketplace, starmap_query) -> Dict[str, Any]:
+        async def push_function(mapped_item, marketplace, starmap_query) -> Dict[str, Any]:
             # Get the push item for the current marketplace
             pi = mapped_item.get_push_item_for_marketplace(marketplace)
 
@@ -324,20 +325,15 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
         # Sequentially publish the uploaded items for each marketplace.
         # It's recommended to do this operation sequentially since parallel publishing in the
         # same marketplace may cause errors due to the change set already being applied.
-        for mapped_item, starmap_query in upload_result:
-            to_await = []
-            executor = Executors.thread_pool(
-                name="pubtools-marketplacesvm-push-regions",
-                max_workers=min(max(len(mapped_item.marketplaces), 1), self._PROCESS_THREADS),
-            )
-
-            for marketplace in mapped_item.marketplaces:
-                to_await.append(
-                    executor.submit(push_function, mapped_item, marketplace, starmap_query)
+        res_output.extend(
+            await asyncio.gather(
+                *(
+                    push_function(mapped_item, marketplace, starmap_query)
+                    for mapped_item, starmap_query in upload_result
+                    for marketplace in mapped_item.marketplaces
                 )
-
-            for f_out in to_await:
-                res_output.append(f_out.result())
+            )
+        )
 
         return res_output
 
@@ -432,7 +428,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
         upload_result = self._push_pre_publish(upload_result)
 
         # 4 - Publish the uploaded images letting the external function to control the threads
-        result = self._push_publish(upload_result)
+        result = asyncio.run(self._push_publish(upload_result))
 
         # process result for failures
         failed = False


### PR DESCRIPTION
This switches the publishing function to an async function. Unlocking it from threads to speed up the publishing. Since publishing generally doesn't do much but just wait around. This still returns the outputs in order similarly to threads.