### PR TITLE
Bump cloudpub to v1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pushcollector>=1.3.0
 pushsource>=2.47.2
 strenum>=0.4.15
 starmap-client>=2.0.0
-cloudpub>=1.2.0
+cloudpub>=1.2.1


### PR DESCRIPTION
This commit bumps cloudpub to apply the following fix:

- Azure Hotfix: Return original SKU if Gen1 & Gen2 are set