### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=get_requirements(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs, lint, mypy, security, py39, py310, py311, py312
+envlist = docs, lint, mypy, security, py39, py310, py311, py312, py313
 
 [testenv]
 envdir = {toxworkdir}/shared-environment


### PR DESCRIPTION
Add support for Python 3.13 which went GA on October 7, 2024.

See: https://devguide.python.org/versions/#supported-versions