### PR TITLE
Adds cloud_info to the pushcollector's clouds.json

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -294,7 +294,10 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
             return {
                 "push_item": push_item_for_collection,
                 "state": pi.state,
-                "marketplace": marketplace,
+                "cloud_info": {
+                    "account": marketplace,
+                    "provider": mapped_item.starmap_query_entity.cloud,
+                },
                 "destinations": mapped_item.starmap_query_entity.mappings[marketplace].destinations,
                 "starmap_query": starmap_query,
             }
@@ -337,6 +340,8 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
             res_dict = asdict(result["push_item"])
             if result.get("starmap_query"):
                 res_dict["starmap_query"] = asdict(result["starmap_query"])
+            if result.get("cloud_info"):
+                res_dict["cloud_info"] = result["cloud_info"]
             # dict can't be modified during iteration.
             # so iterate over list of keys.
             for key in list(res_dict):


### PR DESCRIPTION
This commit includes a new property named `cloud_info` into the PushCollector's `clouds.json`.

This new property is a dictionary containing the provider's short name and it's account name.

Example:
```
[
  {
    "boot_mode": null,
    "build": "rhel-ec2-9.4-20240605.82",
    "build_info": {
      "id": 3099998,
      "name": "rhel-ec2",
      "release": "20240605.82",
      "version": "9.4"
    },
    "cloud_info": {
      "account": "aws-na",
      "provider": "aws"
    },
    ...
  }
]

```

Refers to SPSTRAT-363