### PR TITLE
CommunityWorkflow: Add billing type as custom tags

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/community_push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/community_push/command.py
@@ -497,6 +497,10 @@ class CommunityVMPush(MarketplacesVMPush, AwsRHSMClientService):
                         if content:
                             additional_args[arg] = content
 
+                    # Add the billing type on tags if it's set
+                    if pi.type:
+                        additional_args["custom_tags"] = {"billing_type": pi.type}
+
                     # Generate the push items to upload
                     params = {
                         "marketplace": storage_account,

--- a/tests/community_push/test_community_push.py
+++ b/tests/community_push/test_community_push.py
@@ -871,7 +871,7 @@ def test_do_community_push_different_sharing_accounts(
         [
             mock.call(
                 mock.ANY,
-                custom_tags=None,
+                custom_tags={'billing_type': 'access'},
                 container='redhat-cloudimg-fake-destination',
                 accounts=['first_account', 'second_account'],
                 snapshot_accounts=None,
@@ -879,7 +879,7 @@ def test_do_community_push_different_sharing_accounts(
             ),
             mock.call(
                 mock.ANY,
-                custom_tags=None,
+                custom_tags={'billing_type': 'access'},
                 container='redhat-cloudimg-fake-destination2',
                 accounts=['third_account', 'fourth_account'],
                 snapshot_accounts=None,


### PR DESCRIPTION
This commit changes the community workflow to add the tag `billing_type` into the AMI being uploaded in order to prevent `cloudimg` to seek for the image type `access` and get a resulting `hourly` or vice-versa.

Refers to SPSTRAT-451