### PR TITLE
Fix and Improve the DeleteCommand

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/base.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/base.py
@@ -151,13 +151,15 @@ class CloudProvider(ABC, Generic[T, C]):
         self,
         push_item: T,
         **kwargs,
-    ) -> T:
+    ) -> Tuple[T, Any]:
         """
         Abstract method for deleting images from a public cloud provider.
 
         Args:
             push_item (VMIPushItem)
                 The push item to associate and publish a VM image into a product.
+        Returns:
+            Tuple: The processed push item and the delete result data.
         """
 
     #
@@ -196,7 +198,7 @@ class CloudProvider(ABC, Generic[T, C]):
         """
         return push_item, publish_result
 
-    def _post_delete(self, push_item: T, **kwargs) -> T:
+    def _post_delete(self, push_item: T, delete_result: Any, **kwargs) -> Tuple[T, Any]:
         """
         Define the default method for post publishing actions.
 
@@ -206,9 +208,9 @@ class CloudProvider(ABC, Generic[T, C]):
             delete_result (Any)
                 The resulting data from delete.
         Returns:
-            The delete result data.
+            Tuple: The processed push item and the resulting data from delete.
         """
-        return push_item
+        return push_item, delete_result
 
     #
     # Public interfaces - not intended to be changed by subclasses
@@ -286,7 +288,7 @@ class CloudProvider(ABC, Generic[T, C]):
         self,
         push_item: T,
         **kwargs,
-    ) -> T:
+    ) -> Tuple[T, Any]:
         """
         Associate an existing VM image with a product and publish the changes.
 
@@ -296,10 +298,10 @@ class CloudProvider(ABC, Generic[T, C]):
             builds (List[str])
                 List of builds to delete uploaded images from.
         Returns:
-            object: The publish result data.
+            Tuple: The processed push item and the delete result data.
         """
-        pi = self._delete_push_images(push_item, **kwargs)
-        return self._post_delete(pi, **kwargs)
+        pi, res = self._delete_push_images(push_item, **kwargs)
+        return self._post_delete(pi, res, **kwargs)
 
 
 P = TypeVar('P', bound=CloudProvider)

--- a/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
@@ -341,7 +341,7 @@ class AzureProvider(CloudProvider[VHDPushItem, AzureCredentials]):
 
         return push_item, update_res
 
-    def _delete_push_images(self, push_item, **kwargs):
+    def _delete_push_images(self, push_item, **kwargs) -> Tuple[VHDPushItem, Any]:
         """
         Not implemented for Azure. Passes back push_item without changing anything.
 
@@ -351,11 +351,11 @@ class AzureProvider(CloudProvider[VHDPushItem, AzureCredentials]):
             builds (List[str])
                 The builds to delete.
         Returns:
-            A VHDPushItem
+            A tuple of VHDPushItem and None at the moment.
         """
         # TODO: Add delete functionality to Azure
         LOG.info("Deleting of Azure images from a push is not implemented yet")
-        return push_item
+        return push_item, None
 
     def ensure_offer_is_writable(self, destination: str, nochannel: bool) -> None:
         """

--- a/src/pubtools/_marketplacesvm/tasks/delete/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/delete/command.py
@@ -158,7 +158,7 @@ class VMDelete(MarketplacesVMTask, CloudService, CollectorService, AwsRHSMClient
                     push_item.image_id,
                     marketplace,
                 )
-                pi = self.cloud_instance(marketplace).delete_push_images(
+                pi, _ = self.cloud_instance(marketplace).delete_push_images(
                     push_item, keep_snapshot=self.args.keep_snapshot, **kwargs
                 )
                 log.info(

--- a/tests/delete/test_delete.py
+++ b/tests/delete/test_delete.py
@@ -29,7 +29,7 @@ class FakeCloudProvider(CloudProvider):
         return push_item, nochannel
 
     def _delete_push_images(self, push_item, **kwargs):
-        return push_item
+        return push_item, kwargs
 
 
 @pytest.fixture()
@@ -123,7 +123,6 @@ def test_delete(
     )
 
     fake_source.get.assert_called_once()
-    # There's 2 as the AmiProduct deletes require trying aws-na and aws-emea
     assert fake_cloud_instance.call_count == 2
 
 
@@ -193,7 +192,6 @@ def test_delete_ami_id_not_found_rhsm(
     )
 
     fake_source.get.assert_called_once()
-    # 2 call for RHCOS delete
     assert fake_cloud_instance.call_count == 2
 
 
@@ -269,7 +267,7 @@ def test_delete_failed_one(
             if push_item.image_id not in image_seen:
                 image_seen.append(push_item.image_id)
                 raise Exception("Random exception")
-            return push_item
+            return push_item, kwargs
 
     fake_cloud_instance.return_value = FakePublish()
     command_tester.test(

--- a/tests/logs/delete/test_delete/test_delete.txt
+++ b/tests/logs/delete/test_delete/test_delete.txt
@@ -1,4 +1,5 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-rhcos1 as invisible on RHSM for the provider ACN.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
@@ -7,6 +8,7 @@
 [    INFO] Existing image ami-rhcos1 succesfully updated in rhsm
 [    INFO] Deleting ami-rhcos1 in account aws-china-storage
 [    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
+[   DEBUG] Marking AMI ami-aws1 as invisible on RHSM for the provider AmiProduct.
 [   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
 [    INFO] sample_product not found in RHSM
 [    INFO] Deleting ami-aws1 in account aws-na

--- a/tests/logs/delete/test_delete/test_delete.txt
+++ b/tests/logs/delete/test_delete/test_delete.txt
@@ -1,15 +1,15 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
-[    INFO] Deleting ami-rhcos1 in account aws-china-storage
-[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
 [   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
 [    INFO] Attempting to update the existing image ami-rhcos1 in rhsm
 [    INFO] Existing image ami-rhcos1 succesfully updated in rhsm
-[    INFO] Deleting ami-aws1 in account aws-na
-[    INFO] Delete finished for ami-aws1 in account aws-na
+[    INFO] Deleting ami-rhcos1 in account aws-china-storage
+[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
 [   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
 [    INFO] sample_product not found in RHSM
+[    INFO] Deleting ami-aws1 in account aws-na
+[    INFO] Delete finished for ami-aws1 in account aws-na
 [    INFO] Collecting results
 [    INFO] Delete completed

--- a/tests/logs/delete/test_delete/test_delete_ami_id_not_found_rhsm.txt
+++ b/tests/logs/delete/test_delete/test_delete_ami_id_not_found_rhsm.txt
@@ -1,14 +1,14 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
-[    INFO] Deleting ami-rhcos1 in account aws-china-storage
-[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
 [   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
 [    INFO] Attempting to update the existing image ami-rhcos1 in rhsm
 [    INFO] Existing image ami-rhcos1 succesfully updated in rhsm
+[    INFO] Deleting ami-rhcos1 in account aws-china-storage
+[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
+[ WARNING] AMI image: ami-aws1 not found, skipping update in rhsm.
 [    INFO] Deleting ami-aws1 in account aws-na
 [    INFO] Delete finished for ami-aws1 in account aws-na
-[ WARNING] AMI image: ami-aws1 not found, skipping update in rhsm.
 [    INFO] Collecting results
 [    INFO] Delete completed

--- a/tests/logs/delete/test_delete/test_delete_ami_id_not_found_rhsm.txt
+++ b/tests/logs/delete/test_delete/test_delete_ami_id_not_found_rhsm.txt
@@ -1,4 +1,5 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-rhcos1 as invisible on RHSM for the provider ACN.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
@@ -7,6 +8,7 @@
 [    INFO] Existing image ami-rhcos1 succesfully updated in rhsm
 [    INFO] Deleting ami-rhcos1 in account aws-china-storage
 [    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
+[   DEBUG] Marking AMI ami-aws1 as invisible on RHSM for the provider AmiProduct.
 [ WARNING] AMI image: ami-aws1 not found, skipping update in rhsm.
 [    INFO] Deleting ami-aws1 in account aws-na
 [    INFO] Delete finished for ami-aws1 in account aws-na

--- a/tests/logs/delete/test_delete/test_delete_bad_rhsm.txt
+++ b/tests/logs/delete/test_delete/test_delete_bad_rhsm.txt
@@ -1,8 +1,18 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-rhcos1 as invisible on RHSM for the provider ACN.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
 [   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
 [    INFO] Attempting to update the existing image ami-rhcos1 in rhsm
 [   ERROR] Failed updating image ami-rhcos1
-# Raised: 400 Client Error: None for url: https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
+[ WARNING] Failed to mark ami-rhcos1 invisible on RHSM: 400 Client Error: None for url: https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
+[    INFO] Deleting ami-rhcos1 in account aws-china-storage
+[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
+[   DEBUG] Marking AMI ami-aws1 as invisible on RHSM for the provider AmiProduct.
+[   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
+[    INFO] sample_product not found in RHSM
+[    INFO] Deleting ami-aws1 in account aws-na
+[    INFO] Delete finished for ami-aws1 in account aws-na
+[    INFO] Collecting results
+[    INFO] Delete completed

--- a/tests/logs/delete/test_delete/test_delete_bad_rhsm.txt
+++ b/tests/logs/delete/test_delete/test_delete_bad_rhsm.txt
@@ -1,6 +1,4 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
-[    INFO] Deleting ami-rhcos1 in account aws-china-storage
-[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups

--- a/tests/logs/delete/test_delete/test_delete_dry_run.txt
+++ b/tests/logs/delete/test_delete/test_delete_dry_run.txt
@@ -1,12 +1,12 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
-[    INFO] Would have deleted: ami-rhcos1 in build rhcos-x86_64-414.92.202405201754-0
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
 [   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
 [    INFO] Would have updated image ami-rhcos1 in rhsm
-[    INFO] Would have deleted: ami-aws1 in build sample_product-1.0.1-1-x86_64
+[    INFO] Would have deleted: ami-rhcos1 in build rhcos-x86_64-414.92.202405201754-0
 [   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
 [    INFO] sample_product not found in RHSM
+[    INFO] Would have deleted: ami-aws1 in build sample_product-1.0.1-1-x86_64
 [    INFO] Collecting results
 [    INFO] Delete completed

--- a/tests/logs/delete/test_delete/test_delete_dry_run.txt
+++ b/tests/logs/delete/test_delete/test_delete_dry_run.txt
@@ -1,10 +1,12 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-rhcos1 as invisible on RHSM for the provider ACN.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
 [   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
 [    INFO] Would have updated image ami-rhcos1 in rhsm
 [    INFO] Would have deleted: ami-rhcos1 in build rhcos-x86_64-414.92.202405201754-0
+[   DEBUG] Marking AMI ami-aws1 as invisible on RHSM for the provider AmiProduct.
 [   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
 [    INFO] sample_product not found in RHSM
 [    INFO] Would have deleted: ami-aws1 in build sample_product-1.0.1-1-x86_64

--- a/tests/logs/delete/test_delete/test_delete_failed.txt
+++ b/tests/logs/delete/test_delete/test_delete_failed.txt
@@ -1,4 +1,5 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-rhcos1 as invisible on RHSM for the provider ACN.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups

--- a/tests/logs/delete/test_delete/test_delete_failed.txt
+++ b/tests/logs/delete/test_delete/test_delete_failed.txt
@@ -1,3 +1,9 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
+[   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
+[    INFO] Attempting to update the existing image ami-rhcos1 in rhsm
+[    INFO] Existing image ami-rhcos1 succesfully updated in rhsm
 [    INFO] Deleting ami-rhcos1 in account aws-china-storage
 # Raised: Random exception

--- a/tests/logs/delete/test_delete/test_delete_failed_one.txt
+++ b/tests/logs/delete/test_delete/test_delete_failed_one.txt
@@ -1,4 +1,5 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-aws1 as invisible on RHSM for the provider AmiProduct.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups

--- a/tests/logs/delete/test_delete/test_delete_failed_one.txt
+++ b/tests/logs/delete/test_delete/test_delete_failed_one.txt
@@ -1,3 +1,8 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product sample_product for provider AmiProduct in rhsm
+[   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
+[    INFO] sample_product not found in RHSM
 [    INFO] Deleting ami-aws1 in account aws-na
 # Raised: Random exception

--- a/tests/logs/delete/test_delete/test_delete_skip_build.txt
+++ b/tests/logs/delete/test_delete/test_delete_skip_build.txt
@@ -1,4 +1,5 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
+[   DEBUG] Marking AMI ami-rhcos1 as invisible on RHSM for the provider ACN.
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups

--- a/tests/logs/delete/test_delete/test_delete_skip_build.txt
+++ b/tests/logs/delete/test_delete/test_delete_skip_build.txt
@@ -1,12 +1,12 @@
 [    INFO] Loading items from pub:https://fakepub.com?task-id=12345
-[    INFO] Deleting ami-rhcos1 in account aws-china-storage
-[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
 [   DEBUG] Listing all images from rhsm, https://rhsm.com/v1/internal/cloud_access_providers/amazon/amis
 [   DEBUG] Searching for product sample_product_HOURLY for provider ACN in rhsm
 [   DEBUG] Fetching product from https://rhsm.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
 [   DEBUG] 5 Products(AWS provider) in rhsm: RHEL_HA(awstest), SAP(awstest), rhcos(ACN), sample_product(fake), sample_product_HOURLY(ACN)
 [    INFO] Attempting to update the existing image ami-rhcos1 in rhsm
 [    INFO] Existing image ami-rhcos1 succesfully updated in rhsm
+[    INFO] Deleting ami-rhcos1 in account aws-china-storage
+[    INFO] Delete finished for ami-rhcos1 in account aws-china-storage
 [    INFO] Skipped: ami-aws1 in build sample_product-1.0.1-1-x86_64
 [    INFO] Collecting results
 [    INFO] Delete completed


### PR DESCRIPTION
This PR introduces the following changes to the `VMDelete` command:

- DeleteCommand: Fix delete_push_images interface
- DeleteCommand: Set invisible on RHSM first
- Allow deletion to continue if RHSM update fails

Refers to SPSTRAT-454