### PR TITLE
Adds a wait for product to unlock to post-publish (AWS)

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -626,6 +626,9 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
         restrict_minor = kwargs.get("restrict_minor")
 
         if restrict_version:
+            # Check if this product is locked currently and wait for it to become unlocked
+            LOG.info("Checking for active changesets in: %s", push_item.dest[0])
+            self.publish_svc.wait_active_changesets(push_item.dest[0])
             LOG.info(
                 "Starting to restrict versions: restrict_major = %s, restrict_minor = %s",
                 restrict_major,

--- a/tests/cloud_providers/test_provider_aws.py
+++ b/tests/cloud_providers/test_provider_aws.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from datetime import datetime
 from typing import Any, Dict, Union
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from attrs import evolve
@@ -704,9 +704,7 @@ def test_publish(
     mock_metadata.assert_called_once_with(**metadata)
     fake_aws_provider.publish_svc.publish.assert_called_once_with(meta_obj)
     fake_aws_provider.upload_svc_partial.upload.assert_not_called()  # type: ignore [attr-defined] # noqa: E501
-    fake_aws_provider.publish_svc.wait_active_changesets.assert_called_once_with(
-        aws_push_item.dest[0]
-    )
+    fake_aws_provider.publish_svc.wait_active_changesets.assert_has_calls([call('product-uuid')])
 
 
 @pytest.mark.parametrize("new_base_product", ["test-base", None])
@@ -795,6 +793,7 @@ def test_publish_version_exists(
     assert res == {}
 
     mock_metadata.assert_not_called()
+    fake_aws_provider.publish_svc.wait_active_changesets.assert_has_calls([call('product-uuid')])
     fake_aws_provider.publish_svc.publish.assert_not_called()
     fake_aws_provider.upload_svc_partial.upload.assert_not_called()  # type: ignore [attr-defined] # noqa: E501
 


### PR DESCRIPTION
Adds the wait mechanic to restricting versions. This is being added as there is a chance that a product can be locked by another version being applied when we run the restrict mechanic.

Related to: SPSTRAT-463