### PR TITLE
Do not use relative imports for modules

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/__init__.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/__init__.py
@@ -1,4 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from .aws import AWSCredentials, AWSProvider  # noqa: F401
-from .base import CloudCredentials, CloudProvider, MarketplaceAuth, get_provider  # noqa: F401
-from .ms_azure import AzureCredentials, AzureProvider  # noqa: F401
+from pubtools._marketplacesvm.cloud_providers.aws import AWSCredentials, AWSProvider  # noqa: F401
+from pubtools._marketplacesvm.cloud_providers.base import (  # noqa: F401
+    CloudCredentials,
+    CloudProvider,
+    MarketplaceAuth,
+    get_provider,
+)
+from pubtools._marketplacesvm.cloud_providers.ms_azure import (  # noqa: F401
+    AzureCredentials,
+    AzureProvider,
+)

--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -15,7 +15,12 @@ from cloudpub.aws import AWSVersionMetadata as AWSPublishMetadata
 from cloudpub.models.aws import VersionMapping as AWSVersionMapping
 from pushsource import AmiPushItem
 
-from .base import UPLOAD_CONTAINER_NAME, CloudCredentials, CloudProvider, register_provider
+from pubtools._marketplacesvm.cloud_providers.base import (
+    UPLOAD_CONTAINER_NAME,
+    CloudCredentials,
+    CloudProvider,
+    register_provider,
+)
 
 LOG = logging.getLogger("pubtools.marketplacesvm")
 UploadResult = namedtuple("UploadResult", "id")  # NOSONAR

--- a/src/pubtools/_marketplacesvm/cloud_providers/base.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/base.py
@@ -1,18 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 import os
-import sys
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, NoReturn, Optional, Tuple, Type, TypeVar
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict  # pragma: no cover
-else:
-    from typing_extensions import TypedDict  # pragma: no cover
 
 from attrs import Attribute, field, frozen
 from attrs.validators import instance_of
 from pushsource import VMIPushItem
+from typing_extensions import TypedDict
 
 log = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
@@ -12,7 +12,12 @@ from cloudpub.ms_azure import AzurePublishingMetadata as AzurePublishMetadata
 from cloudpub.ms_azure import AzureService as AzurePublishService
 from pushsource import VHDPushItem
 
-from .base import UPLOAD_CONTAINER_NAME, CloudCredentials, CloudProvider, register_provider
+from pubtools._marketplacesvm.cloud_providers.base import (
+    UPLOAD_CONTAINER_NAME,
+    CloudCredentials,
+    CloudProvider,
+    register_provider,
+)
 
 LOG = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/services/__init__.py
+++ b/src/pubtools/_marketplacesvm/services/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from .cloud import CloudService  # noqa: F401
-from .collector import CollectorService  # noqa: F401
-from .starmap import StarmapService  # noqa: F401
+from pubtools._marketplacesvm.services.cloud import CloudService  # noqa: F401
+from pubtools._marketplacesvm.services.collector import CollectorService  # noqa: F401
+from pubtools._marketplacesvm.services.starmap import StarmapService  # noqa: F401

--- a/src/pubtools/_marketplacesvm/services/cloud.py
+++ b/src/pubtools/_marketplacesvm/services/cloud.py
@@ -6,9 +6,9 @@ import threading
 from argparse import ArgumentParser
 from typing import Any, Dict
 
-from ..arguments import from_environ
-from ..cloud_providers import CloudProvider, MarketplaceAuth, get_provider
-from .base import Service
+from pubtools._marketplacesvm.arguments import from_environ
+from pubtools._marketplacesvm.cloud_providers import CloudProvider, MarketplaceAuth, get_provider
+from pubtools._marketplacesvm.services.base import Service
 
 log = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/services/collector.py
+++ b/src/pubtools/_marketplacesvm/services/collector.py
@@ -2,7 +2,7 @@ import threading
 
 import pushcollector
 
-from .base import Service
+from pubtools._marketplacesvm.services.base import Service
 
 
 class CollectorService(Service):

--- a/src/pubtools/_marketplacesvm/services/rhsm.py
+++ b/src/pubtools/_marketplacesvm/services/rhsm.py
@@ -18,8 +18,8 @@ from more_executors import Executors
 from more_executors.futures import f_map
 from pubtools.pluggy import pm
 
-from ..arguments import from_environ
-from .base import Service
+from pubtools._marketplacesvm.arguments import from_environ
+from pubtools._marketplacesvm.services.base import Service
 
 T = TypeVar("T")
 

--- a/src/pubtools/_marketplacesvm/services/starmap.py
+++ b/src/pubtools/_marketplacesvm/services/starmap.py
@@ -8,8 +8,8 @@ from starmap_client.models import QueryResponseContainer, QueryResponseEntity
 from starmap_client.providers import InMemoryMapProviderV2
 from starmap_client.session import StarmapMockSession, StarmapSession
 
-from ..arguments import RepoFileQueryLoad, RepoQueryLoad
-from .base import Service
+from pubtools._marketplacesvm.arguments import RepoFileQueryLoad, RepoQueryLoad
+from pubtools._marketplacesvm.services.base import Service
 
 log = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/task.py
+++ b/src/pubtools/_marketplacesvm/task.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 from pubtools.pluggy import task_context
 
-from .step import StepDecorator
-from .utils import BuildIdBorg
+from pubtools._marketplacesvm.step import StepDecorator
+from pubtools._marketplacesvm.utils import BuildIdBorg
 
 LOG = logging.getLogger("pubtools.marketplacesvm")
 LOG_FORMAT = "%(asctime)s [%(levelname)-8s] %(message)s"

--- a/src/pubtools/_marketplacesvm/tasks/combined_push/__init__.py
+++ b/src/pubtools/_marketplacesvm/tasks/combined_push/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from .command import CombinedVMPush
+from pubtools._marketplacesvm.tasks.combined_push.command import CombinedVMPush
 
 
 def entry_point(cls=CombinedVMPush):

--- a/src/pubtools/_marketplacesvm/tasks/combined_push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/combined_push/command.py
@@ -4,12 +4,12 @@ from typing import Any, Dict, List
 
 from more_executors import Executors
 
-from ...arguments import SplitAndExtend
-from ...services import CloudService, StarmapService
-from ...services.rhsm import AwsRHSMClientService
-from ...task import RUN_RESULT, MarketplacesVMTask
-from ..community_push import CommunityVMPush
-from ..push import MarketplacesVMPush
+from pubtools._marketplacesvm.arguments import SplitAndExtend
+from pubtools._marketplacesvm.services import CloudService, StarmapService
+from pubtools._marketplacesvm.services.rhsm import AwsRHSMClientService
+from pubtools._marketplacesvm.task import RUN_RESULT, MarketplacesVMTask
+from pubtools._marketplacesvm.tasks.community_push import CommunityVMPush
+from pubtools._marketplacesvm.tasks.push import MarketplacesVMPush
 
 log = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/tasks/community_push/__init__.py
+++ b/src/pubtools/_marketplacesvm/tasks/community_push/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from .command import CommunityVMPush
+from pubtools._marketplacesvm.tasks.community_push.command import CommunityVMPush
 
 
 def entry_point(cls=CommunityVMPush):

--- a/src/pubtools/_marketplacesvm/tasks/community_push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/community_push/command.py
@@ -12,14 +12,13 @@ from requests import HTTPError, Response
 from starmap_client.models import Destination, Workflow
 from typing_extensions import NotRequired
 
+from pubtools._marketplacesvm.cloud_providers.aws import name_from_push_item
+from pubtools._marketplacesvm.services.rhsm import AwsRHSMClientService
+from pubtools._marketplacesvm.task import RUN_RESULT
 from pubtools._marketplacesvm.tasks.community_push.items import ReleaseType, enrich_push_item
-
-from ...cloud_providers.aws import name_from_push_item
-from ...services.rhsm import AwsRHSMClientService
-from ...task import RUN_RESULT
-from ...utils import CLOUD_NAME_FOR_PI
-from ..push import MarketplacesVMPush
-from ..push.items import MappedVMIPushItemV2, State
+from pubtools._marketplacesvm.tasks.push import MarketplacesVMPush
+from pubtools._marketplacesvm.tasks.push.items import MappedVMIPushItemV2, State
+from pubtools._marketplacesvm.utils import CLOUD_NAME_FOR_PI
 
 log = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/tasks/delete/__init__.py
+++ b/src/pubtools/_marketplacesvm/tasks/delete/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from .command import VMDelete
+from pubtools._marketplacesvm.tasks.delete.command import VMDelete
 
 
 def entry_point(cls=VMDelete):

--- a/src/pubtools/_marketplacesvm/tasks/delete/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/delete/command.py
@@ -8,11 +8,11 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 from attrs import asdict, evolve
 from pushsource import AmiPushItem, Source, VHDPushItem, VMIPushItem
 
-from ...arguments import SplitAndExtend
-from ...services import CloudService, CollectorService
-from ...services.rhsm import AwsRHSMClientService
-from ...task import RUN_RESULT, MarketplacesVMTask
-from ..push.items import State
+from pubtools._marketplacesvm.arguments import SplitAndExtend
+from pubtools._marketplacesvm.services import CloudService, CollectorService
+from pubtools._marketplacesvm.services.rhsm import AwsRHSMClientService
+from pubtools._marketplacesvm.task import RUN_RESULT, MarketplacesVMTask
+from pubtools._marketplacesvm.tasks.push.items import State
 
 log = logging.getLogger("pubtools.marketplacesvm")
 

--- a/src/pubtools/_marketplacesvm/tasks/push/__init__.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from .command import MarketplacesVMPush
+from pubtools._marketplacesvm.tasks.push.command import MarketplacesVMPush
 
 
 def entry_point(cls=MarketplacesVMPush):

--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -207,7 +207,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
             # multiple destinations within each marketplace, we may merge the StArMap "meta"
             # safely as the upload will just take advantage of their "sharing_accounts"
             # which es expected to be the same for all destinations within a same marketplace.
-            meta = {}
+            meta: Dict[str, Any] = {}
             for d in pi.dest:
                 meta.update(mapped_item.get_metadata_for_mapped_item(d) or {})
             pi = self._upload(

--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -10,11 +10,11 @@ from more_executors import Executors
 from pushsource import Source, VMIPushItem
 from starmap_client.models import QueryResponseEntity, Workflow
 
-from ...arguments import SplitAndExtend
-from ...services import CloudService, CollectorService, StarmapService
-from ...task import RUN_RESULT, MarketplacesVMTask
-from ...utils import CLOUD_NAME_FOR_PI
-from ..push.items import MappedVMIPushItemV2, State
+from pubtools._marketplacesvm.arguments import SplitAndExtend
+from pubtools._marketplacesvm.services import CloudService, CollectorService, StarmapService
+from pubtools._marketplacesvm.task import RUN_RESULT, MarketplacesVMTask
+from pubtools._marketplacesvm.tasks.push.items import MappedVMIPushItemV2, State
+from pubtools._marketplacesvm.utils import CLOUD_NAME_FOR_PI
 
 log = logging.getLogger("pubtools.marketplacesvm")
 UPLOAD_RESULT = Tuple[MappedVMIPushItemV2, QueryResponseEntity]

--- a/src/pubtools/_marketplacesvm/tasks/push/items/__init__.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/items/__init__.py
@@ -1,4 +1,6 @@
 # The import below is just used to register the converter in MappedVMIPushItem
-from .ami import aws_security_groups_converter  # noqa: F401
-from .starmap import MappedVMIPushItemV2  # noqa: F401
-from .state import State  # noqa: F401
+from pubtools._marketplacesvm.tasks.push.items.ami import (  # noqa: F401 E501
+    aws_security_groups_converter,
+)
+from pubtools._marketplacesvm.tasks.push.items.starmap import MappedVMIPushItemV2  # noqa: F401
+from pubtools._marketplacesvm.tasks.push.items.state import State  # noqa: F401

--- a/src/pubtools/_marketplacesvm/tasks/push/items/ami.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/items/ami.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 from pushsource import AmiAccessEndpointUrl, AmiSecurityGroup
 
-from .starmap import MappedVMIPushItemV2
+from pubtools._marketplacesvm.tasks.push.items.starmap import MappedVMIPushItemV2
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This commit changes the `pubtools-marketplacesvm` source modules to use explicit imports instead of relative ones.