### PR TITLE
Release v1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_requirements():
 
 setup(
     name="pubtools-marketplacesvm",
-    version="1.5.0",
+    version="1.6.0",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     url="https://github.com/release-engineering/pubtools-marketplacesvm",


### PR DESCRIPTION
Changes:

- DeleteCommand: Use cloud_info data when available
- Bump starmap-client to v2.1.1
- Adds --repo-file, can be used to load info from a json file instead of string.
- Changes out repo-file from accepting json to accepting yaml files.
- Adds Azure support to delete command.
- Adds a wait for product to unlock to post-publish (AWS)
- Reverts from asyncio
- Gives Publish more threads to use while avoiding collision.
- Fixes storing data in push_item when an error with rhsm happens.
- Bump cloudpub to v1.3.0