### PR TITLE
Bump cloudpub to v1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pushcollector>=1.3.0
 pushsource>=2.50.0
 strenum>=0.4.15
 starmap-client>=2.1.1
-cloudpub>=1.3.0
+cloudpub>=1.3.1


### PR DESCRIPTION
Bump cloudpub to `v1.3.1` in order to fix the  missing alias for `dateOffset` on Azure