### PR TITLE
AWS: Allow using "snapshot_accouts" from StArMap

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -215,6 +215,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
                 pi,
                 custom_tags=mapped_item.get_tags_for_marketplace(marketplace),
                 accounts=meta.get("sharing_accounts", []),
+                snapshot_accounts=meta.get("snapshot_accounts", []),
                 ami_version_template=mapped_item.get_ami_version_template_for_mapped_item(
                     marketplace
                 ),


### PR DESCRIPTION
This commit updates the `push` command to include the `snapshot_accounts` property from StArMap (whenever avaialble) to be used in the `_push_upload` method.

Refers to RHELDST-29388