### PR TITLE
Do not collect the same push_time more time

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -24,7 +24,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
     """Push and publish content to various cloud marketplaces."""
 
     _REQUEST_THREADS = int(os.environ.get("MARKETPLACESVM_PUSH_REQUEST_THREADS", "5"))
-    _PROCESS_THREADS = int(os.environ.get("MARKETPLACESVM_PUSH_PROCESS_THREADS", "10"))
+    _PROCESS_THREADS = int(os.environ.get("MARKETPLACESVM_PUSH_PROCESS_THREADS", "5"))
     _SKIPPED = False
 
     @property
@@ -303,34 +303,23 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
 
         res_output = []
 
-        # Go through destinations and mappings to ensure that we are pushing
-        # to only a single marketplace + dest at a time.
-        publish_map: Dict[str, List[Dict[str, Any]]] = {}
+        # Sequentially publish the uploaded items for each marketplace.
+        # It's recommended to do this operation sequentially since parallel publishing in the
+        # same marketplace may cause errors due to the change set already being applied.
         for mapped_item, starmap_query in upload_result:
+            to_await = []
+            executor = Executors.thread_pool(
+                name="pubtools-marketplacesvm-push-regions",
+                max_workers=min(max(len(mapped_item.marketplaces), 1), self._PROCESS_THREADS),
+            )
+
             for marketplace in mapped_item.marketplaces:
-                pi = mapped_item.get_push_item_for_marketplace(marketplace)
-                target_name = f"{marketplace}_{pi.dest[0].destination}"
-                if not publish_map.get(target_name):
-                    publish_map[target_name] = []
-                publish_map[target_name].append(
-                    {
-                        "mapped_item": mapped_item,
-                        "marketplace": marketplace,
-                        "starmap_query": starmap_query,
-                    }
+                to_await.append(
+                    executor.submit(push_function, mapped_item, marketplace, starmap_query)
                 )
 
-        to_await = []
-        executor = Executors.thread_pool(
-            name="pubtools-marketplacesvm-push-regions",
-            max_workers=min(max(len(publish_map.keys()), 1), self._PROCESS_THREADS),
-        )
-        for kwargs_list in publish_map.values():
-            for kwargs in kwargs_list:
-                to_await.append(executor.submit(push_function, **kwargs))
-
-                for f_out in to_await:
-                    res_output.append(f_out.result())
+            for f_out in to_await:
+                res_output.append(f_out.result())
 
         return res_output
 

--- a/tests/combined_push/test_combined_push.py
+++ b/tests/combined_push/test_combined_push.py
@@ -95,11 +95,22 @@ def patch_push_objects(
     monkeypatch.setattr(CommunityVMPush, 'starmap', mock_starmap)
 
 
+def _check_collector_update_push_items(
+    mock_collector_update_push_items: mock.MagicMock,
+    expected_ami_pi_count: int,
+) -> None:
+    assert mock_collector_update_push_items.call_count == 1
+    collected_push_items = mock_collector_update_push_items.call_args[0][0]
+    assert len(collected_push_items) == expected_ami_pi_count
+
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_combined_push(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     ami_push_item: AmiPushItem,
     command_tester: CommandTester,
 ) -> None:
@@ -122,13 +133,17 @@ def test_do_combined_push(
         ],
     )
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=10)
+
 
 @pytest.mark.parametrize("fails_on", [CommunityVMPush, MarketplacesVMPush])
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_combined_push_fail_one_workflow(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     fails_on: Union[Type[CommunityVMPush], Type[MarketplacesVMPush]],
     ami_push_item: AmiPushItem,
     monkeypatch: pytest.MonkeyPatch,
@@ -170,12 +185,16 @@ def test_do_combined_push_fail_one_workflow(
         ],
     )
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=10)
 
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_combined_push_both_skipped(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     command_tester: CommandTester,
 ) -> None:
     """Test a combined push which fails as both workflows are empty."""
@@ -197,12 +216,16 @@ def test_do_combined_push_both_skipped(
         ],
     )
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=0)
 
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 def test_do_community_push(
     community_source: mock.MagicMock,
     marketplace_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     ami_push_item: AmiPushItem,
     starmap_query_aws_community: QueryResponseContainer,
     monkeypatch: pytest.MonkeyPatch,
@@ -235,12 +258,16 @@ def test_do_community_push(
     )
     marketplace_source.get.assert_not_called()
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=8)
 
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_marketplace_push(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     ami_push_item: AmiPushItem,
     starmap_query_aws_marketplace: QueryResponseContainer,
     monkeypatch: pytest.MonkeyPatch,
@@ -273,12 +300,16 @@ def test_do_marketplace_push(
     )
     community_source.get.assert_not_called()
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=2)
 
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_advisory_push(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     ami_push_item: AmiPushItem,
     release_params: Dict[str, Any],
     starmap_query_aws_marketplace: QueryResponseContainer,
@@ -331,12 +362,16 @@ def test_do_advisory_push(
         ],
     )
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=10)
 
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_allowed_empty_mapping_push(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     ami_push_item: AmiPushItem,
     release_params: Dict[str, Any],
     starmap_query_aws_marketplace: QueryResponseContainer,
@@ -387,12 +422,16 @@ def test_do_allowed_empty_mapping_push(
         ],
     )
 
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=10)
 
+
+@mock.patch("pushcollector._impl.proxy.CollectorProxy.update_push_items")
 @mock.patch("pubtools._marketplacesvm.tasks.community_push.command.Source")
 @mock.patch("pubtools._marketplacesvm.tasks.push.command.Source")
 def test_do_combined_push_overriden_destination(
     marketplace_source: mock.MagicMock,
     community_source: mock.MagicMock,
+    mock_collector_update_push_items: mock.MagicMock,
     ami_push_item: AmiPushItem,
     starmap_query_aws_marketplace: QueryResponseContainer,
     starmap_query_aws_community: QueryResponseContainer,
@@ -445,3 +484,5 @@ def test_do_combined_push_overriden_destination(
     # Ensure the "server" was not called
     mock_starmap_mkt.query_image_by_name.assert_not_called()
     mock_starmap_cmt.query_image_by_name.assert_not_called()
+
+    _check_collector_update_push_items(mock_collector_update_push_items, expected_ami_pi_count=10)


### PR DESCRIPTION
This reverts the commit "Gives Publish more threads to use while avoiding collision."  2529f6f0a175b5423aa2c3ab408a0be507cd44fa.
    
There were 2 issues:
    * images were published sequentially due to issue in logic SPSTRAT-516
    * some push items were collected more times due to nested for loop SPSTRAT-515

I could fix both issues in the same PR. But I would like to get a feedback to the unit test.