### PR TITLE
Update package name to be compliant with PEP625

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 
 setup(
-    name="pubtools-marketplacesvm",
+    name="pubtools_marketplacesvm",
     version="1.8.1",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},


### PR DESCRIPTION
From PyPI:

```
This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'pubtools-marketplacesvm'.

In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'pubtools-marketplacesvm-1.8.0.tar.gz' is incompatible with PEP 625 because the filename does not contain the normalized project name 'pubtools_marketplacesvm'.

In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.

If you have questions, you can email admin@pypi.org to communicate with the PyPI admin@pypi.org to communicate with the PyPI administrators.
```