### PR TITLE
SPSTRAT-571: Fix AzureService.delete method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ more_executors>=2.11.4
 pushcollector>=1.3.0
 pushsource>=2.50.0
 strenum>=0.4.15
-starmap-client>=2.3.0
-cloudpub>=1.4.0
+starmap-client>=2.4.0
+cloudpub>=1.5.0

--- a/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/ms_azure.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Set, Tuple
 
 from attrs import asdict, evolve, field, frozen
 from attrs.validators import instance_of
+from cloudimg.ms_azure import AzureDeleteMetadata
 from cloudimg.ms_azure import AzurePublishingMetadata as AzureUploadMetadata
 from cloudimg.ms_azure import AzureService as AzureUploadService
 from cloudpub.ms_azure import AzurePublishingMetadata as AzurePublishMetadata
@@ -355,8 +356,13 @@ class AzureProvider(CloudProvider[VHDPushItem, AzureCredentials]):
             A tuple of VHDPushItem and None at the moment.
         """
         name = self._name_from_push_item(push_item)
-        delete_meta_kwargs = {"image_name": name, "container": UPLOAD_CONTAINER_NAME}
-        self.upload_svc.delete(**delete_meta_kwargs)
+        delete_meta_kwargs = {
+            "image_name": name,
+            "image_id": name,
+            "container": UPLOAD_CONTAINER_NAME,
+        }
+        metadata = AzureDeleteMetadata(**delete_meta_kwargs)
+        self.upload_svc.delete(metadata)
         return push_item
 
     def ensure_offer_is_writable(self, destination: str, nochannel: bool) -> None:


### PR DESCRIPTION
This commit changes the `AzureService._delete_push_images` to properly use the `AzureDeleteMetadata` from `cloudimg` which is the expected object for the library's `delete` parameter, instead of passing a dictionary.

Refers to SPSTRAT-571