### PR TITLE
Release v1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_requirements():
 
 setup(
     name="pubtools_marketplacesvm",
-    version="1.8.1",
+    version="1.9.0",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     url="https://github.com/release-engineering/pubtools-marketplacesvm",


### PR DESCRIPTION
Changes:

* Drop support for python 3.9 by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/113
* SPSTRAT-571: Fix AzureService.delete method by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/114
* SPSTRAT-574: Support --limit parameter on VMDelete by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/115
* bugfix: Use grouped items since pre_push by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/117
* SPSTRAT-575: Iterate over all marketplaces before deleting items by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/116
* Update package name to be compliant with PEP625 by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/110

## Summary by Sourcery

Prepare v1.9.0 release by bumping the version and incorporating VM deletion enhancements, AzureService fixes, and package compliance updates

New Features:
- Support --limit parameter on VMDelete to restrict deletion count per invocation
- Iterate over all configured marketplaces before deleting items to ensure comprehensive cleanup

Bug Fixes:
- Fix AzureService.delete method to handle item deletion correctly
- Use grouped items since pre_push to resolve grouping inconsistencies

Enhancements:
- Drop support for Python 3.9 to align with minimum Python 3.10 requirement
- Update package name to comply with PEP 625 standard

Chores:
- Bump package version to 1.9.0