### PR TITLE
AWS: Add converter for boot_mode

### DIFF
--- a/src/pubtools/_marketplacesvm/tasks/push/items/ami.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/items/ami.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List
 
-from pushsource import AmiAccessEndpointUrl, AmiSecurityGroup
+from pushsource import AmiAccessEndpointUrl, AmiSecurityGroup, BootMode
 
 from .starmap import MappedVMIPushItemV2
 
@@ -36,5 +36,19 @@ def aws_access_endpoint_url_converter(value: Dict[str, Any]) -> AmiAccessEndpoin
     return AmiAccessEndpointUrl._from_data(value)
 
 
+def aws_boot_mode_converter(value: str) -> BootMode:
+    """
+    Convert boot_mode string value to BootMode enum.
+
+    Args:
+        value (str): boot_mode as string
+
+    Returns:
+        BootMode: The corresponding Enum for the received value
+    """
+    return BootMode(value)
+
+
 MappedVMIPushItemV2.register_converter("security_groups", aws_security_groups_converter)
 MappedVMIPushItemV2.register_converter("access_endpoint_url", aws_access_endpoint_url_converter)
+MappedVMIPushItemV2.register_converter("boot_mode", aws_boot_mode_converter)


### PR DESCRIPTION
This commit adds a new StArMap converter for `AmiPushItem` to convert the `boot_mode` from `str` to `BootMode`.

It also adds new tests to validate the conversion.

Refers to SPSTRAT-600

## Summary by Sourcery

Add support for converting boot_mode metadata to the BootMode enum by implementing and registering a new converter and covering it with dedicated tests

New Features:
- Add aws_boot_mode_converter to convert boot_mode strings to the BootMode enum

Enhancements:
- Register the boot_mode converter for AmiPushItem mappings in MappedVMIPushItemV2

Tests:
- Add parameterized tests for aws_boot_mode_converter and extend metadata override tests to include boot_mode