### PR TITLE
Add Ashwini Kumar as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@JAVGan @jajreidy @lslebodn
+*	@JAVGan @jajreidy @lslebodn @ashwgit


### PR DESCRIPTION
Adding Ashwini as codeowner as he's assigned to our project.

## Summary by Sourcery

Chores:
- Add Ashwini Kumar to .github/CODEOWNERS as a project code owner