### PR TITLE
ci: normalize tox environment names for Python matrix

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Install Tox
         run: pip install tox
       - name: Test on ${{ matrix.python-version }}
-        run: tox -e "py${{ matrix.python-version }}"
+        run: |
+          PY_VER=${{ matrix.python-version }}
+          tox -e "py${PY_VER//./}"
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Tox v4.50.1+ introduced stricter environment name validation, preventing dotted versions (e.g., py3.12) from silently falling back to normalized definitions (e.g., py312).

https://tox.wiki/en/latest/changelog.html#bug-fixes-4-50-1

@JAVGan @ashwgit  PTAL

## Summary by Sourcery

CI:
- Update tox-test GitHub Actions workflow to strip dots from matrix Python versions when constructing tox environment names.