### PR TITLE
Fix "mypy" issues

### DIFF
--- a/src/pubtools/_marketplacesvm/services/starmap.py
+++ b/src/pubtools/_marketplacesvm/services/starmap.py
@@ -23,8 +23,8 @@ class StarmapService(Service):
 
     def __init__(self, *args, **kwargs) -> None:
         """Instantiate a StarmapService object."""
-        self._instance = None
-        self._container = None
+        self._instance: Optional[StarmapClient] = None
+        self._container: Optional[QueryResponseContainer] = None
         self._lock = threading.Lock()
         super(StarmapService, self).__init__(*args, **kwargs)
 
@@ -96,12 +96,15 @@ class StarmapService(Service):
                 session_klass = StarmapSession if not offline else StarmapMockSession
                 session = session_klass(self._service_args.starmap_url, api_version="v2")
                 self._instance = StarmapClient(session=session, **kwargs)
+        if self._instance is None:
+            raise RuntimeError("StArMap client instance failed to initialize")
+
         return self._instance
 
     def _store_container_responses(self, qrc: QueryResponseContainer) -> None:
         for qre in qrc.responses:
-            if qre not in self._container.responses:  # type: ignore [attr-defined]
-                self._container.responses.append(qre)  # type: ignore [attr-defined]
+            if self._container and qre not in self._container.responses:
+                self._container.responses.append(qre)
 
     def _query_server(self, name: str, version: Optional[str]) -> List[QueryResponseEntity]:
         qrc = self.starmap.query_image_by_name(name=name, version=version)

--- a/src/pubtools/_marketplacesvm/tasks/community_push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/community_push/command.py
@@ -257,7 +257,8 @@ class CommunityVMPush(MarketplacesVMPush, AwsRHSMClientService):
         # The `sharing_accounts` in a similar way of the marketplace workflow, while maintaining the
         # previous `accounts` format for retrocompatibility.
         def set_accounts(acct_name: str, acct_dict: Dict[str, List[str]]) -> None:
-            accts = destination.meta.get(acct_name)
+            meta = destination.meta or {}
+            accts = meta.get(acct_name)
             if not accts:
                 log.warning(
                     "No %s definition in StArMap, leaving the defaults from credentials.", acct_name
@@ -308,7 +309,7 @@ class CommunityVMPush(MarketplacesVMPush, AwsRHSMClientService):
                 for dest in mrobj.destinations:
                     pi = mapped_item.get_push_item_for_destination(dest)
                     log.debug("Mapped push item for %s: %s", storage_account, pi)
-                    r = dest.meta.get("release") or {}
+                    r = (dest.meta or {}).get("release") or {}
                     r_type_str = str(r.get("type", "")).lower()
                     r_type_str = "beta" if self.args.beta else r_type_str
                     if r_type_str:

--- a/src/pubtools/_marketplacesvm/tasks/push/command.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/command.py
@@ -72,7 +72,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
         Returns
             The wrapped push item with the additional information from StArMap.
         """
-        mapped_items = []
+        mapped_items: List[Dict[str, Union[MappedVMIPushItemV2, QueryResponseEntity]]] = []
         for item in self.raw_items:
             log.info("Retrieving the mappings for %s from %s", item.name, self.args.starmap_url)
             binfo = item.build_info
@@ -221,14 +221,17 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
             meta = {}
             for d in pi.dest:
                 meta.update(mapped_item.get_metadata_for_mapped_item(d) or {})
+            kwargs: Dict[str, Any] = {}
+            if pi.dest:
+                kwargs["ami_version_template"] = (
+                    mapped_item.get_ami_version_template_for_mapped_item(pi.dest[0])
+                )
             pi = self._upload(
                 marketplace,
                 pi,
                 custom_tags=mapped_item.get_tags_for_marketplace(marketplace),
                 accounts=meta.get("sharing_accounts", []),
-                ami_version_template=mapped_item.get_ami_version_template_for_mapped_item(
-                    marketplace
-                ),
+                **kwargs,
             )
             mapped_item.update_push_item_for_marketplace(marketplace, pi)
         return mapped_item, starmap_query
@@ -279,7 +282,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
                 mapped_item = release_data["mapped_item"]
                 marketplace = release_data["marketplace"]
                 destination = release_data["destination"]
-                starmap_meta = destination.meta
+                starmap_meta = destination.meta or {}
                 modular_push = bool(starmap_meta.get("modular_push", False))
 
                 # Get the push item for the current marketplace
@@ -329,7 +332,7 @@ class MarketplacesVMPush(MarketplacesVMTask, CloudService, CollectorService, Sta
                 marketplace = publish_data["marketplace"]
                 destination = publish_data["destination"]
                 starmap_query = publish_data["starmap_query"]
-                starmap_meta = destination.meta
+                starmap_meta = destination.meta or {}
                 modular_push = starmap_meta.get("modular_push", False)
 
                 # Get the push item for the current marketplace

--- a/src/pubtools/_marketplacesvm/tasks/push/items/starmap.py
+++ b/src/pubtools/_marketplacesvm/tasks/push/items/starmap.py
@@ -176,7 +176,7 @@ class MappedVMIPushItemV2:
             )
             self._mapped_push_item[account] = pi
 
-        return self._mapped_push_item.get(account)
+        return self._mapped_push_item[account]
 
     def get_push_item_for_marketplace_and_destination(
         self, account: str, destination: Destination
@@ -223,7 +223,7 @@ class MappedVMIPushItemV2:
         """
         for dst in self.destinations:
             if dst == destination:
-                return dst.meta
+                return dst.meta or {}
         return {}
 
     def get_tags_for_mapped_item(self, destination: Destination) -> Dict[str, str]:
@@ -237,7 +237,7 @@ class MappedVMIPushItemV2:
         """
         for dst in self.destinations:
             if dst == destination:
-                return dst.tags
+                return dst.tags or {}
         return {}
 
     def get_ami_version_template_for_mapped_item(self, destination: Destination) -> str:
@@ -251,7 +251,7 @@ class MappedVMIPushItemV2:
         """
         for dst in self.destinations:
             if dst == destination:
-                return dst.ami_version_template
+                return dst.ami_version_template or ""
         return ""
 
     def get_tags_for_marketplace(self, account: str) -> Dict[str, str]:

--- a/tests/community_push/conftest.py
+++ b/tests/community_push/conftest.py
@@ -153,6 +153,5 @@ def mapped_ami_push_item(
 ) -> AmiPushItem:
     destinations = []
     for mrobj in starmap_query_aws.responses[0].mappings.values():
-        for dest in mrobj:
-            destinations.append(dest)
+        destinations.extend(mrobj.destinations)
     return evolve(ami_push_item, dest=destinations)

--- a/tests/community_push/test_community_push.py
+++ b/tests/community_push/test_community_push.py
@@ -755,12 +755,13 @@ def test_no_rhsm_url(
 def test_not_in_rhsm(
     fake_starmap: mock.MagicMock,
     fake_source: mock.MagicMock,
-    starmap_query_aws: QueryResponseEntity,
+    starmap_query_aws: QueryResponseContainer,
     command_tester: CommandTester,
 ) -> None:
     """Ensure there's an error when the product is not in RHSM."""
     for mrojb in starmap_query_aws.responses[0].mappings.values():
         for dest in mrojb.destinations:
+            assert dest.meta is not None
             dest.meta["release"]["product"] = "not_in_rhsm_product"
 
     command_tester.test(

--- a/tests/push/test_mapped_pushitem.py
+++ b/tests/push/test_mapped_pushitem.py
@@ -148,6 +148,7 @@ def test_release_info_on_metadata_for_mapped_ami(
     # We simulate having the "release" dict on each Destination for StArMap response.
     for mapping in starmap_query_aws.all_mappings:
         for dest in mapping.destinations:
+            assert dest.meta is not None
             dest.meta["release"] = release_info
 
     # Test whether the MappedVMIPushItemV2 can return the inner push item with the proper release
@@ -188,6 +189,7 @@ def test_release_info_on_metadata_for_mapped_vhd(
     # We simulate having the "release" dict on each Destination for StArMap response.
     for mapping in starmap_query_aws.all_mappings:
         for dest in mapping.destinations:
+            assert dest.meta is not None
             dest.meta["release"] = release_info
 
     # Test whether the MappedVMIPushItemV2 can return the inner push item with the proper release
@@ -212,7 +214,7 @@ def test_get_tags_for_mapped_item(
 
     # Test existing destinations
     for dest in starmap_query_azure.mappings["azure-na"].destinations:
-        assert mapped_item.get_tags_for_mapped_item(dest) == dest.tags or {}
+        assert mapped_item.get_tags_for_mapped_item(dest) == (dest.tags or {})
 
     # Test unknown destination
     dest = Destination.from_json(
@@ -243,7 +245,7 @@ def test_get_ami_template_for_marketplace(
     # Test existing destinations
     for dest in starmap_query_aws.mappings["aws-na"].destinations:
         avt = mapped_item.get_ami_version_template_for_mapped_item(dest)
-        assert avt == dest.ami_version_template or ""
+        assert avt == (dest.ami_version_template or "")
 
     # Test unknown destination
     dest = Destination.from_json(

--- a/tests/services/test_services.py
+++ b/tests/services/test_services.py
@@ -45,6 +45,17 @@ def test_starmap_service() -> None:
 
 
 @patch("pubtools._marketplacesvm.services.starmap.StarmapClient")
+def test_starmap_service_failed_initialize(mock_client: MagicMock) -> None:
+    instance = MarketplacesVMPush()
+    arg = ["", "-d", "fakesource"]
+    mock_client.return_value = None
+
+    with patch.object(sys, "argv", arg):
+        with pytest.raises(RuntimeError, match="StArMap client instance failed to initialize"):
+            _ = instance.starmap
+
+
+@patch("pubtools._marketplacesvm.services.starmap.StarmapClient")
 def test_starmap_query(mock_client: MagicMock) -> None:
     """Ensure the `StarmapService.query_image_by_name` is properly working."""
     data = load_json("tests/data/starmap/container.json")


### PR DESCRIPTION
Fix issues caught by the most up to date version of `mypy`

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>

Assisted-by: Cursor/Gemini

## Summary by Sourcery

Address type-safety issues reported by newer mypy by tightening typing annotations, handling optional metadata safely, and aligning tests with the updated types and behaviors.

Bug Fixes:
- Prevent potential None-related failures by defaulting destination metadata, tags, and AMI templates to empty structures or strings when missing.
- Ensure Starmap service and mapped push item access patterns are type-safe and non-optional where required, avoiding runtime key or attribute errors.

Enhancements:
- Refine type annotations for Starmap service internals, mapped items, and test fixtures to comply with stricter static analysis.
- Simplify and clarify test utilities and expectations to better reflect the structure of StArMap responses.

Tests:
- Adjust existing tests to assert non-null metadata, use the correct StArMap response container type, and align expectations with new defaulting behavior for tags and AMI templates.