### PR TITLE
Release v2.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_requirements():
 
 setup(
     name="pubtools_marketplacesvm",
-    version="2.1.1",
+    version="2.1.2",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     url="https://github.com/release-engineering/pubtools-marketplacesvm",


### PR DESCRIPTION
Changes:

* Bump pushsource, pubtools and Remove setuptools by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/141
* ci: normalize tox environment names for Python matrix by @lslebodn in https://github.com/release-engineering/pubtools-marketplacesvm/pull/142
* Fix "mypy" issues by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/144
* Bump cloudpub & starmap-client by @JAVGan in https://github.com/release-engineering/pubtools-marketplacesvm/pull/143

## Summary by Sourcery

Bump the pubtools_marketplacesvm package version to 2.1.2 for the new release.