### PR TITLE
Fix mypy error for untyped __CLOUD_PROVIDERS variable

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/base.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/base.py
@@ -21,7 +21,7 @@ T = TypeVar("T", bound=VMIPushItem)
 
 UPLOAD_CONTAINER_NAME = os.getenv("UPLOAD_CONTAINER_NAME", "pubupload")
 
-__CLOUD_PROVIDERS = {}
+__CLOUD_PROVIDERS: Dict[str, Type["CloudProvider"]] = {}
 
 
 class MarketplaceAuth(TypedDict):


### PR DESCRIPTION
Add type annotation to __CLOUD_PROVIDERS dict in cloud_providers/base.py to resolve mypy var-annotated error.

## Summary by Sourcery

Enhancements:
- Add a precise Dict[str, Type[CloudProvider]] annotation to the __CLOUD_PROVIDERS mapping to address mypy errors.