### PR TITLE
Add nightly scheduled GitHub Actions workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,124 @@
+name: Nightly tests
+
+on:
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Tox
+        run: pip install tox 'virtualenv<20.21.1'
+      - name: Run Linting
+        run: tox -e lint
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Tox
+        run: pip install tox 'virtualenv<20.21.1'
+      - name: Run MyPy
+        run: tox -e mypy
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Install Tox
+        run: pip install tox
+      - name: Test on ${{ matrix.python-version }}
+        run: |
+          PY_VER=${{ matrix.python-version }}
+          tox -e "py${PY_VER//./}"
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Tox
+        run: pip install tox 'virtualenv<20.21.1'
+      - name: Install pytest cov
+        run: pip install pytest-cov
+      - name: Run Tox
+        run: tox -e coverage
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Tox
+        run: pip install tox 'virtualenv<20.21.1'
+      - name: Run Tox
+        run: tox -e security
+      - name: Install project
+        run: python -m pip install .
+      - name: Run pip-audit
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          inputs: requirements.txt requirements-test.txt
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Tox
+        run: pip install tox 'virtualenv<20.21.1'
+      - name: Run Tox
+        run: tox -e docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: "23 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a new `nightly.yml` workflow that runs the full tox test suite weekly on Mondays at 6:23 AM UTC 
- Includes all jobs from `tox-test.yml`: linting, mypy, unit tests (Python 3.10-3.13), coverage, security, and docs
- Supports manual triggering via `workflow_dispatch`

## Test plan
- [ ] Verify workflow syntax is valid by triggering manually from the Actions tab
- [ ] Confirm scheduled runs appear after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Introduce a nightly GitHub Actions workflow that runs linting, type checks, unit tests across Python 3.10–3.13, coverage, security scans, and docs via tox on a daily cron schedule with manual dispatch support.