### PR TITLE
GH actions: fixes and improvements

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get install -y libkrb5-dev
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e docs
       - name: Publish

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Linting
         run: tox -e lint
   mypy:
@@ -40,7 +40,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run MyPy
         run: tox -e mypy
   unit-tests:
@@ -80,7 +80,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Run Tox
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e security
       - name: Install project
@@ -122,6 +122,6 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -33,8 +32,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -58,8 +56,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Test on ${{ matrix.python-version }}
@@ -73,8 +70,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -92,8 +88,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -115,8 +110,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,8 +77,6 @@ jobs:
           python-version: "3.10"
       - name: Install Tox
         run: pip install tox
-      - name: Install pytest cov
-        run: pip install pytest-cov
       - name: Run Tox
         run: tox -e coverage
   security:

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -10,8 +10,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -27,8 +26,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -52,8 +50,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Test on ${{ matrix.python-version }}
@@ -67,8 +64,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -86,8 +82,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -109,8 +104,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Linting
         run: tox -e lint
   mypy:
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run MyPy
         run: tox -e mypy
   unit-tests:
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Run Tox
@@ -93,7 +93,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e security
       - name: Install project
@@ -116,7 +116,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e docs
 

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -71,8 +71,6 @@ jobs:
           python-version: "3.10"
       - name: Install Tox
         run: pip install tox
-      - name: Install pytest cov
-        run: pip install pytest-cov
       - name: Run Tox
         run: tox -e coverage
   security:


### PR DESCRIPTION
# Changes

## GH Actions: Remove venv workaronud
    
Remove the virtualenv<20.21.1 during setup tox

## GH Actions: Improve Install OS packages

Use single line `apt-get install` command for multiple packages on  "Install OS packages"

## GH Actions: do not install pytest-cov
    
It's already present in requirements-test.txt

## Summary by Sourcery

Simplify GitHub Actions workflows by removing a legacy virtualenv version pin from tox installation and consolidating OS package installation into a single apt-get command.

Build:
- Update GitHub Actions workflows to install tox without pinning virtualenv to a specific version.
- Streamline GitHub Actions OS package installation by combining multiple apt-get install invocations into one command.