### PR TITLE
AWS: add fallback for build_info.version

### DIFF
--- a/src/pubtools/_marketplacesvm/cloud_providers/aws.py
+++ b/src/pubtools/_marketplacesvm/cloud_providers/aws.py
@@ -407,7 +407,10 @@ class AWSProvider(CloudProvider[AmiPushItem, AWSCredentials]):
             tags.update(custom_tags)
 
         if push_item.src.startswith("ami"):
-            tags["version"] = push_item.build.split("-")[2]
+            version = (
+                push_item.build.split("-")[2] if push_item.build else push_item.build_info.version
+            )
+            tags["version"] = version
             tags["nvra"] = (
                 f"{binfo.name}-{tags['version']}-{binfo.release}.{push_item.release.arch}"  # noqa: E501
             )

--- a/tests/cloud_providers/test_provider_aws.py
+++ b/tests/cloud_providers/test_provider_aws.py
@@ -282,6 +282,38 @@ def test_upload_of_rhcos_image(
     )
 
 
+def test_upload_of_rhcos_image_without_build(
+    aws_rhcos_push_item: AmiPushItem,
+    fake_aws_provider: AWSProvider,
+):
+    push_item = evolve(aws_rhcos_push_item, build=None)
+    binfo = push_item.build_info
+
+    tags = {
+        "arch": push_item.release.arch,
+        "buildid": str(push_item.build_info.id),
+        "name": push_item.build_info.name,
+        "nvra": f"{binfo.name}-{binfo.version}-{binfo.release}.{push_item.release.arch}",
+        "release": push_item.build_info.release,
+        "version": binfo.version,
+    }
+
+    fake_aws_provider.upload_svc_partial.return_value.get_image_from_ami_catalog.return_value = (
+        FakeImageResp()
+    )
+    fake_aws_provider.upload_svc_partial.return_value.copy_ami.return_value = {
+        "ImageId": "fake-ami-02"
+    }
+    fake_aws_provider.upload_svc_partial.return_value.get_image_by_name.return_value = None
+    fake_aws_provider.upload_svc_partial.return_value.get_image_by_id.return_value = "test_image"
+
+    _, result = fake_aws_provider.upload(push_item)
+    assert result.id == "fake-ami-02"
+    fake_aws_provider.upload_svc_partial.return_value.tag_image.assert_called_once_with(
+        "test_image", tags
+    )
+
+
 def test_upload_of_rhcos_image_not_found(
     aws_rhcos_push_item: AmiPushItem,
     fake_aws_provider: AWSProvider,


### PR DESCRIPTION
This commit adds a fallback for loading the `version` from an existing AMI whenever such information is not present in the `push_item.build`.

With this change it will look for the
`push_item.build_info.version` whenever the `push_item.build` is not properly set, which may happen when using a staging structure to load an existing AMI.

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>

Assisted-by: Cursor/Gemini

## Summary by Sourcery

Add a fallback to derive the AMI version tag from build_info when build is missing during AWS RHCOS image uploads.

Bug Fixes:
- Ensure AMI version and NVRA tags are correctly populated when push_item.build is not set by using build_info.version as a fallback.

Tests:
- Add coverage for uploading an RHCOS image without build metadata to verify version tagging falls back to build_info.version.