### PR TITLE
actions: update release.yaml to deploy on PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - run: pip install build
+    - run: python -m build
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The way we were using to deploy on PyPI via token is no longer required due to the use of Trusted Publishing.

I got the following email from it:

```
An API token belonging to user JAVGan was used to upload files to the project cloudpub, even though the project has a Trusted Publisher configured. This may have been in error. We recommend removing the API token and only using the Trusted Publisher to publish.

If you are the owner of this token, you can delete it by going to your API tokens configuration and deleting the token named publish_stuff.

If you believe this was done in error, you can email admin@pypi.org to communicate with the PyPI administrators.
```

This commit updates the PyPI deployment to rely on `pypa/gh-action-pypi-publish@release/v1` which uses the Trusted Publishing.

## Summary by Sourcery

CI:
- Adjust release.yml workflow to build with python -m build and publish to PyPI via pypa/gh-action-pypi-publish using Trusted Publishing.