### PR TITLE
fix: use the permissions & environment for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python


### PR DESCRIPTION
Fix the release action to use the missing environment and permissions to push to PyPI

## Summary by Sourcery

Configure the release workflow to use the PyPI environment with appropriate permissions for deployments.

CI:
- Grant OIDC id-token write permissions to the release job in the GitHub Actions workflow.
- Associate the release job with the PyPI environment to enable publishing.